### PR TITLE
The File.exists? method was deprecated in Ruby 2.2 and removed in Rub…

### DIFF
--- a/lib/spi/driver/spidev.rb
+++ b/lib/spi/driver/spidev.rb
@@ -9,7 +9,7 @@ class SPI
 
       def initialize(args={})
         raise SPIException, "No Device specified" if args[:device].nil?
-        raise SPIException, "Device #{args[:device]} not found" unless File.exists?(args[:device])
+        raise SPIException, "Device #{args[:device]} not found" unless File.exist?(args[:device])
         @device = File.open(args[:device])
         @mode=getMode
         @bits=getBits


### PR DESCRIPTION
…y 3.2. The correct method to use is File.exist? (without the 's')